### PR TITLE
Fix TileEntityPowerTap.isOutput()

### DIFF
--- a/src/main/java/com/bymarcin/zettaindustries/mods/battery/tileentity/TileEntityPowerTap.java
+++ b/src/main/java/com/bymarcin/zettaindustries/mods/battery/tileentity/TileEntityPowerTap.java
@@ -197,7 +197,7 @@ public class TileEntityPowerTap extends BasicRectangularMultiblockTileEntityBase
 	}
 	
 	public boolean isOutput() {
-		return worldObj.getBlockMetadata(xCoord, yCoord, zCoord)==0;
+		return blockMetadata==0;
 	}
 	
 	@Override


### PR DESCRIPTION
This entity can get its own int field blockMetadata without having to call worldObj.getBlockMetadata() which is just wasteful.
Original method caused excessive lag.