### PR TITLE
Introduce BuildCraft-like unsafe TE loading

### DIFF
--- a/src/main/java/com/bymarcin/zettaindustries/utils/WorldUtils.java
+++ b/src/main/java/com/bymarcin/zettaindustries/utils/WorldUtils.java
@@ -6,24 +6,72 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import cofh.api.energy.IEnergyHandler;
+import net.minecraft.world.ChunkCoordIntPair;
+import net.minecraft.world.ChunkPosition;
+import net.minecraft.world.Explosion;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraft.world.gen.ChunkProviderServer;
 
 import com.bymarcin.zettaindustries.ZettaIndustries;
 
 public class WorldUtils {
 	public static final ForgeDirection[] flatDirections = new ForgeDirection[]{ForgeDirection.EAST, ForgeDirection.NORTH, ForgeDirection.SOUTH, ForgeDirection.WEST};
 
+	/*
+		Original methods from ZIndustries modified to fit BuildCraft-style "forced chunk" methods
+	*/
 	public static TileEntity getTileEntity(int dimensionId, int x, int y, int z) {
-		World world = ZettaIndustries.proxy.getWorld(dimensionId);
-		if (world == null)
-			return null;
-		return world.getTileEntity(x, y, z);
+		return this.getTileEntity(dimensionId, x, y, z, true);
 	}
-
+	
 	public static TileEntity getTileEntityServer(int dimensionId, int x, int y, int z) {
+		return this.getTileEntity(dimensionId, x, y, z, true);
+	}
+	
+	public static TileEntity getTileEntity(int dimensionId, int x, int y, int z, boolean force) {
+		World world = ZettaIndustries.proxy.getWorld(dimensionId);
+		return world == null ? null : this.getTileEntity(world, x, y, z, true);
+	}
+	
+	public static TileEntity getTileEntityServer(int dimensionId, int x, int y, int z, boolean force) {
 		World world = MinecraftServer.getServer().worldServerForDimension(dimensionId);
-		if (world == null)
-			return null;
-		return world.getTileEntity(x, y, z);
+		return world == null ? null : this.getTileEntity(world, x, y, z, true);
+	}
+	
+	/**
+	 * Methods adapted from BuildCraft
+	 */
+	 
+	private static TileEntity getTileEntity(World world, int x, int y, int z, boolean force) {
+		if (!force) {
+			if (y < 0 || y > 255) {
+				return null;
+			}
+			Chunk chunk = getChunkUnforced(world, x >> 4, z >> 4);
+			return chunk != null ? chunk.getTileEntityUnsafe(x & 15, y, z & 15) : null;
+		} else return world.getTileEntity(x, y, z);
+	}
+	
+	private static Chunk lastChunk;
+
+	private static Chunk getChunkUnforced(World world, int x, int z) {
+		Chunk chunk = lastChunk;
+		if (chunk != null) {
+			if (chunk.isChunkLoaded) {
+				if (chunk.worldObj == world && chunk.xPosition == x && chunk.zPosition == z) {
+					return chunk;
+				}
+			} else {
+				lastChunk = null;
+			}
+		}
+
+		chunk = world.getChunkProvider().chunkExists(x, z) ? world.getChunkProvider().provideChunk(x, z) : null;
+		lastChunk = chunk;
+		return chunk;
 	}
 
 	public static boolean isClientWorld(World paramWorld) {
@@ -33,6 +81,7 @@ public class WorldUtils {
 	public static boolean isServerWorld(World paramWorld) {
 		return !paramWorld.isRemote;
 	}
+
 
 	public static TileEntity getAdjacentTileEntity(World paramWorld, int paramInt1, int paramInt2, int paramInt3, ForgeDirection paramForgeDirection)
 	{


### PR DESCRIPTION
See BuildCraft diff https://github.com/BuildCraft/BuildCraft/commit/b9755f7915cb3da157f1a78544287a34caf44b5c#diff-9f8dfb7472feb65ea7e82fc9e36a03f3

This will introduce the option to unsafely load TileEntities like in BuildCraft, useful in some situations (see tiles in diff which were modified).
Will help reduce lag if used properly.
